### PR TITLE
Initial project structure with basic C template

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+AllowShortIfStatementsOnASingleLine: false
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Build files
+*.o
+main
+
+# Backup files
+*~
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Marcos Paulo Pazzinatto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      
+copies of the Software, and to permit persons to whom the Software is         
+furnished to do so, subject to the following conditions:                       
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.                                
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+SOFTWARE.
+

--- a/include/main.h
+++ b/include/main.h
@@ -1,0 +1,7 @@
+#ifndef MAIN_H
+#define MAIN_H
+
+void print_greeting(void);
+
+#endif
+

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include "main.h"
+
+int main(void) {
+    print_greeting();
+    return 0;
+}
+

--- a/src/print.c
+++ b/src/print.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include "main.h"
+
+void print_greeting(void) {
+    printf("Hello, World!\n");
+}
+


### PR DESCRIPTION
This PR adds the initial structure for the C Template Project, including:

- Standard folder layout (`src/`, `include/`, `build/`)
- Basic `main.c` and `main.h` implementation with a greeting function
- Optional modular `print.c` file for better separation
- `Makefile` for building and cleaning the project
- `.gitignore` for temporary and build files
- `.clang-format` with custom styling
- `README.md` with usage instructions
- `LICENSE` (MIT)

This setup serves as a clean starting point for C programming projects with simple build automation and consistent formatting.
